### PR TITLE
Squashed support for multilanguage T9 dialer (1/2)

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -31,6 +31,11 @@ src_dirs += \
     $(phone_common_dir)/src-N
 
 LOCAL_SRC_FILES := $(call all-java-files-under, $(src_dirs)) $(call all-Iaidl-files-under, $(src_dirs))
+
+LOCAL_SRC_FILES += ../../providers/ContactsProvider/src/com/android/providers/contacts/NameSplitter.java \
+                   ../../providers/ContactsProvider/src/com/android/providers/contacts/HanziToPinyin.java \
+                   ../../providers/ContactsProvider/src/com/android/providers/contacts/util/NeededForTesting.java
+
 LOCAL_RESOURCE_DIR := $(addprefix $(LOCAL_PATH)/, $(res_dirs)) \
     $(support_library_root_dir)/v7/cardview/res \
     $(support_library_root_dir)/v7/recyclerview/res \

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -27,6 +27,11 @@
     <string name="nearby_places">Nearby places</string>
     <string name="people">People</string>
 
+    <!-- dialpad t9 search -->
+    <string name="preference_category_t9_dialpad_search">Dialpad T9 search</string>
+    <string name="t9_search_input_locale">T9 search input</string>
+    <string name="t9_search_input_locale_default">Default</string>
+
     <!-- Number lookup -->
     <string name="lookup_settings_label">Phone number lookup</string>
     <string name="enable_forward_lookup_title">Forward lookup</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1063,4 +1063,7 @@
 
     <!-- Accessibility announcement to indicate which call is active -->
     <string name="accessibility_call_is_active"><xliff:g id="nameOrNumber">^1</xliff:g> is active</string>
+
+    <string name="missing_account_type">(No type)</string>
+    <string name="missing_account_name">(No name)</string>
 </resources>

--- a/res/xml/display_options_settings.xml
+++ b/res/xml/display_options_settings.xml
@@ -28,4 +28,11 @@
         android:title="@string/display_options_view_names_as"
         android:dialogTitle="@string/display_options_view_names_as" />
 
+    <ListPreference
+        android:key="button_t9_search_input"
+        android:title="@string/t9_search_input_locale"
+        android:summary="%s"
+        android:defaultValue=""
+        android:persistent="false" />
+
 </PreferenceScreen>

--- a/src/com/android/dialer/dialpad/DialpadFragment.java
+++ b/src/com/android/dialer/dialpad/DialpadFragment.java
@@ -30,6 +30,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -105,6 +106,7 @@ import static android.Manifest.permission.WRITE_CALL_LOG;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Fragment that displays a twelve-key phone dialpad.
@@ -729,6 +731,12 @@ public class DialpadFragment extends Fragment
         // Long-pressing pound button will enter ';'(wait) instead.
         final DialpadKeyButton pound = (DialpadKeyButton) fragmentView.findViewById(R.id.pound);
         pound.setOnLongClickListener(this);
+    }
+
+    public void refreshKeypad() {
+        if (mDialpadView != null) {
+            mDialpadView.refreshKeypad();
+        }
     }
 
     @Override

--- a/src/com/android/dialer/dialpad/GreekSmartDialMap.java
+++ b/src/com/android/dialer/dialpad/GreekSmartDialMap.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright (C) 2014 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.android.dialer.dialpad;
 
 import java.util.ArrayList;
 
-public class LatinSmartDialMap implements SmartDialMap {
+public class GreekSmartDialMap implements SmartDialMap {
 
     private static final char[] LATIN_LETTERS_TO_DIGITS = {
         '2', '2', '2', // A,B,C -> 2
@@ -15,9 +31,20 @@ public class LatinSmartDialMap implements SmartDialMap {
         '9', '9', '9', '9' // W,X,Y,Z -> 9
     };
 
+    private static final char[] GREEK_LETTERS_TO_DIGITS = {
+        '2', '2', '2', // Α,Β,Γ -> 2
+        '3', '3', '3', // Δ,Ε,Ζ -> 3
+        '4', '4', '4', // Η,Θ,Ι -> 4
+        '5', '5', '5', // Κ,Λ,Μ -> 5
+        '6', '6', '6', // Ν,Ξ,Ο -> 6
+        '7', '7', '7', '7', // Π,Ρ,Σ,ς -> 7
+        '8', '8', '8', // Τ,Υ,Φ -> 8
+        '9', '9', '9'  // Χ,Ψ,Ω -> 9
+    };
+
     @Override
     public boolean isValidDialpadAlphabeticChar(char ch) {
-        return (ch >= 'a' && ch <= 'z');
+        return (ch >= 'a' && ch <= 'z') || (ch >= 'α' && ch <= 'ω');
     }
 
     @Override
@@ -388,6 +415,44 @@ public class LatinSmartDialMap implements SmartDialMap {
             case 'X': return 'x';
             case 'Y': return 'y';
             case 'Z': return 'z';
+            case 'Α': return 'α';
+            case 'Ά': return 'α';
+            case 'ά': return 'α';
+            case 'Β': return 'β';
+            case 'Γ': return 'γ';
+            case 'Δ': return 'δ';
+            case 'Ε': return 'ε';
+            case 'Έ': return 'ε';
+            case 'έ': return 'ε';
+            case 'Ζ': return 'ζ';
+            case 'Η': return 'η';
+            case 'Ή': return 'η';
+            case 'ή': return 'η';
+            case 'Θ': return 'θ';
+            case 'Ι': return 'ι';
+            case 'Ί': return 'ι';
+            case 'ί': return 'ι';
+            case 'Κ': return 'κ';
+            case 'Λ': return 'λ';
+            case 'Μ': return 'μ';
+            case 'Ν': return 'ν';
+            case 'Ξ': return 'ξ';
+            case 'Ο': return 'ο';
+            case 'Ό': return 'ο';
+            case 'ό': return 'ο';
+            case 'Π': return 'π';
+            case 'Ρ': return 'ρ';
+            case 'Σ': return 'σ';
+            case 'Τ': return 'τ';
+            case 'Υ': return 'υ';
+            case 'Ύ': return 'υ';
+            case 'ύ': return 'υ';
+            case 'Φ': return 'φ';
+            case 'Χ': return 'χ';
+            case 'Ψ': return 'ψ';
+            case 'Ω': return 'ω';
+            case 'Ώ': return 'ω';
+            case 'ώ': return 'ω';
             default:
                 return ch;
         }
@@ -399,6 +464,8 @@ public class LatinSmartDialMap implements SmartDialMap {
             return (byte) (ch - '0');
         } else if (ch >= 'a' && ch <= 'z') {
             return (byte) (LATIN_LETTERS_TO_DIGITS[ch - 'a'] - '0');
+        } else if (ch >= 'α' && ch <= 'ω') {
+            return (byte) (GREEK_LETTERS_TO_DIGITS[ch - 'α'] - '0');
         } else {
             return -1;
         }
@@ -408,6 +475,9 @@ public class LatinSmartDialMap implements SmartDialMap {
     public char getDialpadNumericCharacter(char ch) {
         if (ch >= 'a' && ch <= 'z') {
             return LATIN_LETTERS_TO_DIGITS[ch - 'a'];
+        }
+        if (ch >= 'α' && ch <= 'ω') {
+            return GREEK_LETTERS_TO_DIGITS[ch - 'α'];
         }
         return ch;
     }

--- a/src/com/android/dialer/dialpad/HebrewSmartDialMap.java
+++ b/src/com/android/dialer/dialpad/HebrewSmartDialMap.java
@@ -2,7 +2,7 @@ package com.android.dialer.dialpad;
 
 import java.util.ArrayList;
 
-public class LatinSmartDialMap implements SmartDialMap {
+public class HebrewSmartDialMap implements SmartDialMap {
 
     private static final char[] LATIN_LETTERS_TO_DIGITS = {
         '2', '2', '2', // A,B,C -> 2
@@ -15,9 +15,20 @@ public class LatinSmartDialMap implements SmartDialMap {
         '9', '9', '9', '9' // W,X,Y,Z -> 9
     };
 
+    private static final char[] HEBREW_LETTERS_TO_DIGITS = {
+        '3', '3', '3',      // אבג -> 3
+        '2', '2', '2',      // דהו -> 2
+        '6', '6', '6',      // זחט -> 6
+        '5', '5', '5', '5', // יךכל -> 5
+        '4', '4', '4', '4', // םמןנ -> 4
+        '9', '9', '9', '9', // סעףפ -> 9
+        '8', '8', '8',      // ץצק -> 8
+        '7', '7', '7',      // רשת -> 7
+    };
+
     @Override
     public boolean isValidDialpadAlphabeticChar(char ch) {
-        return (ch >= 'a' && ch <= 'z');
+        return (ch >= 'a' && ch <= 'z') || (ch >= 'א' && ch <= 'ת');
     }
 
     @Override
@@ -30,23 +41,6 @@ public class LatinSmartDialMap implements SmartDialMap {
         return (isValidDialpadAlphabeticChar(ch) || isValidDialpadNumericChar(ch));
     }
 
-    /*
-     * The switch statement in this function was generated using the python code:
-     * from unidecode import unidecode
-     * for i in range(192, 564):
-     *     char = unichr(i)
-     *     decoded = unidecode(char)
-     *     # Unicode characters that decompose into multiple characters i.e.
-     *     #  into ss are not supported for now
-     *     if (len(decoded) == 1 and decoded.isalpha()):
-     *         print "case '" + char + "': return '" + unidecode(char) +  "';"
-     *
-     * This gives us a way to map characters containing accents/diacritics to their
-     * alphabetic equivalents. The unidecode library can be found at:
-     * http://pypi.python.org/pypi/Unidecode/0.04.1
-     *
-     * Also remaps all upper case latin characters to their lower case equivalents.
-     */
     @Override
     public char normalizeCharacter(char ch) {
         switch (ch) {
@@ -388,6 +382,12 @@ public class LatinSmartDialMap implements SmartDialMap {
             case 'X': return 'x';
             case 'Y': return 'y';
             case 'Z': return 'z';
+            // ending letter in Hebrew (מןץףך)
+            case 'ך': return 'כ';
+            case 'ם': return 'מ';
+            case 'ן': return 'נ';
+            case 'ף': return 'פ';
+            case 'ץ': return 'צ';
             default:
                 return ch;
         }
@@ -399,6 +399,8 @@ public class LatinSmartDialMap implements SmartDialMap {
             return (byte) (ch - '0');
         } else if (ch >= 'a' && ch <= 'z') {
             return (byte) (LATIN_LETTERS_TO_DIGITS[ch - 'a'] - '0');
+        } else if (ch >= 'א' && ch <= 'ת') {
+            return (byte) (HEBREW_LETTERS_TO_DIGITS[ch - 'א'] - '0');
         } else {
             return -1;
         }
@@ -408,6 +410,9 @@ public class LatinSmartDialMap implements SmartDialMap {
     public char getDialpadNumericCharacter(char ch) {
         if (ch >= 'a' && ch <= 'z') {
             return LATIN_LETTERS_TO_DIGITS[ch - 'a'];
+        }
+        if (ch >= 'א' && ch <= 'ת') {
+            return HEBREW_LETTERS_TO_DIGITS[ch - 'א'];
         }
         return ch;
     }

--- a/src/com/android/dialer/dialpad/RussianSmartDialMap.java
+++ b/src/com/android/dialer/dialpad/RussianSmartDialMap.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright (C) 2014 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.android.dialer.dialpad;
 
 import java.util.ArrayList;
 
-public class LatinSmartDialMap implements SmartDialMap {
+public class RussianSmartDialMap implements SmartDialMap {
 
     private static final char[] LATIN_LETTERS_TO_DIGITS = {
         '2', '2', '2', // A,B,C -> 2
@@ -15,9 +31,20 @@ public class LatinSmartDialMap implements SmartDialMap {
         '9', '9', '9', '9' // W,X,Y,Z -> 9
     };
 
+    private static final char[] RUSSIAN_LETTERS_TO_DIGITS = {
+        '2', '2', '2', '2', // абвг -> 2
+        '3', '3', '3', '3', // дежз -> 3
+        '4', '4', '4', '4', // ийкл -> 4
+        '5', '5', '5', '5', // мноп -> 5
+        '6', '6', '6', '6', // рсту -> 6
+        '7', '7', '7', '7', // фхцч -> 7
+        '8', '8', '8', '8', // шщъы -> 8
+        '9', '9', '9', '9'  // ьэюя -> 9
+    };
+
     @Override
     public boolean isValidDialpadAlphabeticChar(char ch) {
-        return (ch >= 'a' && ch <= 'z');
+        return (ch >= 'a' && ch <= 'z') || (ch >= 'а' && ch <= 'я');
     }
 
     @Override
@@ -388,6 +415,40 @@ public class LatinSmartDialMap implements SmartDialMap {
             case 'X': return 'x';
             case 'Y': return 'y';
             case 'Z': return 'z';
+            case 'А': return 'а';
+            case 'Б': return 'б';
+            case 'В': return 'в';
+            case 'Г': return 'г';
+            case 'Д': return 'д';
+            case 'Е': return 'е';
+            case 'ё': return 'е';
+            case 'Ё': return 'е';
+            case 'Ж': return 'ж';
+            case 'З': return 'з';
+            case 'И': return 'и';
+            case 'Й': return 'й';
+            case 'К': return 'к';
+            case 'Л': return 'л';
+            case 'М': return 'м';
+            case 'Н': return 'н';
+            case 'О': return 'о';
+            case 'П': return 'п';
+            case 'Р': return 'р';
+            case 'С': return 'с';
+            case 'Т': return 'т';
+            case 'У': return 'у';
+            case 'Ф': return 'ф';
+            case 'Х': return 'х';
+            case 'Ц': return 'ц';
+            case 'Ч': return 'ч';
+            case 'Ш': return 'ш';
+            case 'Щ': return 'щ';
+            case 'Ъ': return 'ъ';
+            case 'Ы': return 'ы';
+            case 'Ь': return 'ь';
+            case 'Э': return 'э';
+            case 'Ю': return 'ю';
+            case 'Я': return 'я';
             default:
                 return ch;
         }
@@ -399,6 +460,8 @@ public class LatinSmartDialMap implements SmartDialMap {
             return (byte) (ch - '0');
         } else if (ch >= 'a' && ch <= 'z') {
             return (byte) (LATIN_LETTERS_TO_DIGITS[ch - 'a'] - '0');
+        } else if (ch >= 'а' && ch <= 'я') {
+            return (byte) (RUSSIAN_LETTERS_TO_DIGITS[ch - 'а'] - '0');
         } else {
             return -1;
         }
@@ -408,6 +471,9 @@ public class LatinSmartDialMap implements SmartDialMap {
     public char getDialpadNumericCharacter(char ch) {
         if (ch >= 'a' && ch <= 'z') {
             return LATIN_LETTERS_TO_DIGITS[ch - 'a'];
+        }
+        if (ch >= 'а' && ch <= 'я') {
+            return RUSSIAN_LETTERS_TO_DIGITS[ch - 'а'];
         }
         return ch;
     }

--- a/src/com/android/dialer/dialpad/SmartDialCursorLoader.java
+++ b/src/com/android/dialer/dialpad/SmartDialCursorLoader.java
@@ -103,6 +103,8 @@ public class SmartDialCursorLoader extends AsyncTaskLoader<Cursor> {
             row[PhoneQuery.PHOTO_ID] = contact.photoId;
             row[PhoneQuery.DISPLAY_NAME] = contact.displayName;
             row[PhoneQuery.CARRIER_PRESENCE] = contact.carrierPresence;
+            row[PhoneQuery.PHONE_ACCOUNT_TYPE] = contact.accountType;
+            row[PhoneQuery.PHONE_ACCOUNT_NAME] = contact.accountName;
             cursor.addRow(row);
         }
         return cursor;

--- a/src/com/android/dialer/dialpad/SmartDialMap.java
+++ b/src/com/android/dialer/dialpad/SmartDialMap.java
@@ -1,5 +1,7 @@
 package com.android.dialer.dialpad;
 
+import java.util.ArrayList;
+
 /**
  * Note: These methods currently take characters as arguments. For future planned language support,
  * they will need to be changed to use codepoints instead of characters.
@@ -40,4 +42,15 @@ public interface SmartDialMap {
      * from accented characters.
      */
     public char normalizeCharacter(char ch);
+
+    /*
+     * Allow the SmartDialMaps to convert the characters if needed.
+     */
+    public String transliterateName(String index);
+
+    /*
+     * Allow the SmartDialMaps to provide their own character to dialpad matching if needed.
+     */
+    public boolean matchesCombination(SmartDialNameMatcher smartDialNameMatcher, String displayName, String query,
+            ArrayList<SmartDialMatchPosition> matchList);
 }

--- a/src/com/android/dialer/dialpad/SmartDialNameMatcher.java
+++ b/src/com/android/dialer/dialpad/SmartDialNameMatcher.java
@@ -18,12 +18,15 @@ package com.android.dialer.dialpad;
 
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
+import android.util.Log;
 
+import com.android.dialer.database.DialerDatabaseHelper;
 import com.android.dialer.dialpad.SmartDialPrefix.PhoneNumberTokens;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 
 /**
@@ -34,6 +37,8 @@ import java.util.ArrayList;
  * whether we allow matches like 57 - (J)ohn (S)mith.
  */
 public class SmartDialNameMatcher {
+
+    private final static String TAG = "SmartDialNameMatcher";
 
     private String mQuery;
 
@@ -46,16 +51,16 @@ public class SmartDialNameMatcher {
 
     private final ArrayList<SmartDialMatchPosition> mMatchPositions = Lists.newArrayList();
 
-    public static final SmartDialMap LATIN_SMART_DIAL_MAP = new LatinSmartDialMap();
-
     private final SmartDialMap mMap;
 
     private String mNameMatchMask = "";
     private String mPhoneNumberMatchMask = "";
 
+    private String mSchar = "+*#-.(,)/ ";
+
     @VisibleForTesting
     public SmartDialNameMatcher(String query) {
-        this(query, LATIN_SMART_DIAL_MAP);
+        this(query, SmartDialPrefix.getMap());
     }
 
     public SmartDialNameMatcher(String query, SmartDialMap map) {
@@ -135,22 +140,6 @@ public class SmartDialNameMatcher {
 
         // Try matching the number as is
         SmartDialMatchPosition matchPos = matchesNumberWithOffset(phoneNumber, query, 0);
-        if (matchPos == null) {
-            final PhoneNumberTokens phoneNumberTokens =
-                    SmartDialPrefix.parsePhoneNumber(phoneNumber);
-
-            if (phoneNumberTokens == null) {
-                return matchPos;
-            }
-            if (phoneNumberTokens.countryCodeOffset != 0) {
-                matchPos = matchesNumberWithOffset(phoneNumber, query,
-                        phoneNumberTokens.countryCodeOffset);
-            }
-            if (matchPos == null && phoneNumberTokens.nanpCodeOffset != 0 && useNanp) {
-                matchPos = matchesNumberWithOffset(phoneNumber, query,
-                        phoneNumberTokens.nanpCodeOffset);
-            }
-        }
         if (matchPos != null) {
             replaceBitInMask(builder, matchPos);
             mPhoneNumberMatchMask = builder.toString();
@@ -195,40 +184,47 @@ public class SmartDialNameMatcher {
      */
     private SmartDialMatchPosition matchesNumberWithOffset(String phoneNumber, String query,
             int offset) {
-        if (TextUtils.isEmpty(phoneNumber) || TextUtils.isEmpty(query)) {
+        if (TextUtils.isEmpty(phoneNumber) || TextUtils.isEmpty(query)
+                || query.length() > phoneNumber.length()) {
             return null;
         }
-        int queryAt = 0;
-        int numberAt = offset;
-        for (int i = offset; i < phoneNumber.length(); i++) {
-            if (queryAt == query.length()) {
-                break;
-            }
-            char ch = phoneNumber.charAt(i);
-            if (mMap.isValidDialpadNumericChar(ch)) {
-                if (ch != query.charAt(queryAt)) {
-                    return null;
+
+        String phoneNum = phoneNumber.replaceAll("[\\+\\*\\#\\-\\.\\(\\,\\)\\/ ]", "");
+        if (!TextUtils.isEmpty(phoneNum) && phoneNum.contains(query)) {
+            // firstly, find the start position in original phone number.
+            int start = phoneNum.indexOf(query);
+            int length = phoneNumber.length();
+            for (int i = start; i < length; i++) {
+                char ch = phoneNumber.charAt(i);
+                if (ch != phoneNum.charAt(start)) {
+                    continue;
                 }
-                queryAt++;
-            } else {
-                if (queryAt == 0) {
-                    // Found a separator before any part of the query was matched, so advance the
-                    // offset to avoid prematurely highlighting separators before the rest of the
-                    // query.
-                    // E.g. don't highlight the first '-' if we're matching 1-510-111-1111 with
-                    // '510'.
-                    // However, if the current offset is 0, just include the beginning separators
-                    // anyway, otherwise the highlighting ends up looking weird.
-                    // E.g. if we're matching (510)-111-1111 with '510', we should include the
-                    // first '('.
-                    if (offset != 0) {
-                        offset++;
-                    }
+                if (phoneNumber.substring(i).replaceAll("[\\+\\*\\#\\-\\.\\(\\,\\)\\/ ]", "")
+                        .indexOf(query) == 0) {
+                    start = i;
+                    break;
                 }
             }
-            numberAt++;
+            // secondly, find the end position in original phone number.
+            int specialCount = 0;
+            int queryLength = query.length();
+            int end = start + queryLength;
+            for (int i = start; i < length; i++) {
+                char ch = phoneNumber.charAt(i);
+                if (mSchar.indexOf(ch) != -1) {
+                    specialCount++;
+                    continue;
+                }
+
+                if (i - start + 1 - specialCount == queryLength) {
+                    end = i + 1;
+                    break;
+                }
+            }
+            return new SmartDialMatchPosition(start, end);
+        } else {
+            return null;
         }
-        return new SmartDialMatchPosition(0 + offset, numberAt);
     }
 
     /**
@@ -412,7 +408,7 @@ public class SmartDialNameMatcher {
 
     public boolean matches(String displayName) {
         mMatchPositions.clear();
-        return matchesCombination(displayName, mQuery, mMatchPositions);
+        return mMap.matchesCombination(this, displayName, mQuery, mMatchPositions);
     }
 
     public ArrayList<SmartDialMatchPosition> getMatchPositions() {

--- a/src/com/android/dialer/dialpad/SmartDialPrefix.java
+++ b/src/com/android/dialer/dialpad/SmartDialPrefix.java
@@ -23,12 +23,20 @@ import android.preference.PreferenceManager;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 
+import com.android.dialer.database.DialerDatabaseHelper;
+import com.android.dialerbind.DatabaseHelperManager;
+import com.android.phone.common.util.SettingsUtil;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.Locale;
+import java.util.Map;
+import java.util.HashMap;
+
+import android.util.Log;
 
 /**
  * Smart Dial utility class to find prefixes of contacts. It contains both methods to find supported
@@ -65,9 +73,32 @@ public class SmartDialPrefix {
     private static Set<String> sCountryCodes = null;
 
     /** Dialpad mapping. */
-    private static final SmartDialMap mMap = new LatinSmartDialMap();
+    private static SmartDialMap mMap = null;
 
     private static boolean sNanpInitialized = false;
+
+    private static final Map<String, SmartDialMap> languageToSmartDialMap = new HashMap<String, SmartDialMap>();
+    static {
+        languageToSmartDialMap.put("ko", new KoreanSmartDialMap());
+        languageToSmartDialMap.put("el", new GreekSmartDialMap());
+        languageToSmartDialMap.put("ru", new RussianSmartDialMap());
+        languageToSmartDialMap.put("uk", new UkrainianSmartDialMap());
+        // Per Locale.java documentation:
+        // Note that Java uses several deprecated two-letter codes. The Hebrew ("he") language
+        // code is rewritten as "iw"
+        languageToSmartDialMap.put("iw", new HebrewSmartDialMap());
+        languageToSmartDialMap.put("zh", new ChineseSmartDialMap());
+    }
+
+    private static final Map<String, SmartDialMap> countryToSmartDialMap = new HashMap<String, SmartDialMap>();
+    static {
+        languageToSmartDialMap.put("KR", new KoreanSmartDialMap());
+        languageToSmartDialMap.put("GR", new GreekSmartDialMap());
+        languageToSmartDialMap.put("RU", new RussianSmartDialMap());
+        languageToSmartDialMap.put("UA", new UkrainianSmartDialMap());
+        languageToSmartDialMap.put("IL", new HebrewSmartDialMap());
+        languageToSmartDialMap.put("CN", new ChineseSmartDialMap());
+    }
 
     /** Initializes the Nanp settings, and finds out whether user is in a NANP region.*/
     public static void initializeNanpSettings(Context context){
@@ -89,7 +120,22 @@ public class SmartDialPrefix {
         }
         /** Queries the NANP country list to find out whether user is in a NANP region.*/
         sUserInNanpRegion = isCountryNanp(sUserSimCountryCode);
+
+        /** Sets a layout for SmartDial based on locale.  Lookup by language first and fallback to country */
+        Locale locale = SettingsUtil.getT9SearchInputLocale(context);
+        mMap = languageToSmartDialMap.get(locale.getLanguage());
+        if (mMap == null)
+            mMap = countryToSmartDialMap.get(locale.getCountry());
+        if (mMap == null)
+            mMap = new LatinSmartDialMap();
+
         sNanpInitialized = true;
+    }
+
+    // for testing only
+    @VisibleForTesting
+    static void setSmartDialMap(SmartDialMap map) {
+        mMap = map;
     }
 
     /**
@@ -165,7 +211,7 @@ public class SmartDialPrefix {
      */
     public static ArrayList<String> generateNamePrefixes(String index) {
         final ArrayList<String> result = Lists.newArrayList();
-
+        index = mMap.transliterateName(index);
         /** Parses the name into a list of tokens.*/
         final ArrayList<String> indexTokens = parseToIndexTokens(index);
 
@@ -280,9 +326,9 @@ public class SmartDialPrefix {
                 /** If the number does not start with '+', finds out whether it is in NANP
                  * format and has '1' preceding the number.
                  */
-                if ((normalizedNumber.length() == 11) && (normalizedNumber.charAt(0) == '1') &&
-                        (sUserInNanpRegion)) {
-                    countryCode = "1";
+                if ((normalizedNumber.length() == 11) && (normalizedNumber.charAt(0) == '1'
+                     || normalizedNumber.charAt(0) == '7') && (sUserInNanpRegion)) {
+                    countryCode = normalizedNumber.substring(0, 1);
                     countryCodeOffset = number.indexOf(normalizedNumber.charAt(1));
                     if (countryCodeOffset == -1) {
                         countryCodeOffset = 0;
@@ -298,7 +344,8 @@ public class SmartDialPrefix {
                      * NANP area code, and finds out offset of the local number.
                      */
                     areaCode = normalizedNumber.substring(0, 3);
-                } else if (countryCode.equals("1") && normalizedNumber.length() == 11) {
+                } else if ((countryCode.equals("1") || countryCode.equals("7")) &&
+                            normalizedNumber.length() == 11) {
                     /** If the number has country code '1', finds out area code and offset of the
                      * local number.
                      */
@@ -594,6 +641,8 @@ public class SmartDialPrefix {
         result.add("TT"); // Trinidad and Tobago
         result.add("TC"); // Turks and Caicos Islands
         result.add("VI"); // U.S. Virgin Islands
+        result.add("RU"); // Russia
+        result.add("UA"); // Ukraine
         return result;
     }
 

--- a/src/com/android/dialer/dialpad/UkrainianSmartDialMap.java
+++ b/src/com/android/dialer/dialpad/UkrainianSmartDialMap.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright (C) 2015 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.android.dialer.dialpad;
 
 import java.util.ArrayList;
 
-public class LatinSmartDialMap implements SmartDialMap {
+public class UkrainianSmartDialMap implements SmartDialMap {
 
     private static final char[] LATIN_LETTERS_TO_DIGITS = {
         '2', '2', '2', // A,B,C -> 2
@@ -15,9 +31,22 @@ public class LatinSmartDialMap implements SmartDialMap {
         '9', '9', '9', '9' // W,X,Y,Z -> 9
     };
 
+    private static final char[] UKRANIAN_LETTERS_TO_DIGITS = {
+        '2', '2', '2', '2', // абвг(ґ) -> 2
+        '3', '3', '3', '3', // де(є)жз -> 3
+        '4', '4', '4', '4', // и(ії)йкл -> 4
+        '5', '5', '5', '5', // мноп -> 5
+        '6', '6', '6', '6', // рсту -> 6
+        '7', '7', '7', '7', // фхцч -> 7
+        '8', '8',           // шщ -> 8
+        '9', '9', '9',      // ьюя -> 9
+
+        '3', '4', '4', '2'  // є,і,ї,ґ are out of the alpha sequence in unicode
+    };
+
     @Override
     public boolean isValidDialpadAlphabeticChar(char ch) {
-        return (ch >= 'a' && ch <= 'z');
+        return (ch >= 'a' && ch <= 'z') || (ch >= 'а' && ch <= 'ґ');
     }
 
     @Override
@@ -388,6 +417,44 @@ public class LatinSmartDialMap implements SmartDialMap {
             case 'X': return 'x';
             case 'Y': return 'y';
             case 'Z': return 'z';
+            case 'А': return 'а';
+            case 'Б': return 'б';
+            case 'В': return 'в';
+            case 'Г': return 'г';
+            case 'Ґ': return 'ґ';
+            case 'Д': return 'д';
+            case 'Е': return 'е';
+            case 'ё': return 'е';
+            case 'Ё': return 'е';
+            case 'Є': return 'є';
+            case 'Ж': return 'ж';
+            case 'З': return 'з';
+            case 'И': return 'и';
+            case 'І': return 'і';
+            case 'Ї': return 'ї';
+            case 'Й': return 'й';
+            case 'К': return 'к';
+            case 'Л': return 'л';
+            case 'М': return 'м';
+            case 'Н': return 'н';
+            case 'О': return 'о';
+            case 'П': return 'п';
+            case 'Р': return 'р';
+            case 'С': return 'с';
+            case 'Т': return 'т';
+            case 'У': return 'у';
+            case 'Ф': return 'ф';
+            case 'Х': return 'х';
+            case 'Ц': return 'ц';
+            case 'Ч': return 'ч';
+            case 'Ш': return 'ш';
+            case 'Щ': return 'щ';
+            case 'Ъ': return 'ъ';
+            case 'Ы': return 'ы';
+            case 'Ь': return 'ь';
+            case 'Э': return 'э';
+            case 'Ю': return 'ю';
+            case 'Я': return 'я';
             default:
                 return ch;
         }
@@ -399,6 +466,19 @@ public class LatinSmartDialMap implements SmartDialMap {
             return (byte) (ch - '0');
         } else if (ch >= 'a' && ch <= 'z') {
             return (byte) (LATIN_LETTERS_TO_DIGITS[ch - 'a'] - '0');
+        } else if (ch >= 'а' && ch <= 'я') {
+            int skipCodes = 0;
+            if (ch >= 'ь') skipCodes += 2;
+            if (ch >= 'ю') skipCodes += 1;
+            return (byte) (UKRANIAN_LETTERS_TO_DIGITS[ch - 'а' - skipCodes] - '0');
+        } else if (ch >= 'є' && ch <= 'ґ') {
+            switch (ch) {
+                case 'є': return (byte)3;
+                case 'і': return (byte)4;
+                case 'ї': return (byte)4;
+                case 'ґ': return (byte)2;
+                default:  return -1;
+            }
         } else {
             return -1;
         }
@@ -408,6 +488,21 @@ public class LatinSmartDialMap implements SmartDialMap {
     public char getDialpadNumericCharacter(char ch) {
         if (ch >= 'a' && ch <= 'z') {
             return LATIN_LETTERS_TO_DIGITS[ch - 'a'];
+        }
+        if (ch >= 'а' && ch <= 'я') {
+            int skipCodes = 0;
+            if (ch >= 'ь') skipCodes += 2;
+            if (ch >= 'ю') skipCodes += 1;
+            return UKRANIAN_LETTERS_TO_DIGITS[ch - 'а' - skipCodes];
+        }
+        if (ch >= 'є' && ch <= 'ґ') {
+            switch (ch) {
+                case 'є': return '3';
+                case 'і': return '4';
+                case 'ї': return '4';
+                case 'ґ': return '2';
+                default:  return ch;
+            }
         }
         return ch;
     }

--- a/src/com/android/dialer/list/SmartDialNumberListAdapter.java
+++ b/src/com/android/dialer/list/SmartDialNumberListAdapter.java
@@ -41,11 +41,13 @@ public class SmartDialNumberListAdapter extends DialerPhoneNumberListAdapter {
     private static final String TAG = SmartDialNumberListAdapter.class.getSimpleName();
     private static final boolean DEBUG = false;
 
+    private final Context mContext;
+
     private SmartDialNameMatcher mNameMatcher;
 
     public SmartDialNumberListAdapter(Context context) {
         super(context);
-        mNameMatcher = new SmartDialNameMatcher("", SmartDialPrefix.getMap());
+        mContext = context;
         setShortcutEnabled(SmartDialNumberListAdapter.SHORTCUT_DIRECT_CALL, false);
 
         if (DEBUG) {
@@ -60,6 +62,8 @@ public class SmartDialNumberListAdapter extends DialerPhoneNumberListAdapter {
         if (DEBUG) {
             Log.v(TAG, "Configure Loader with query" + getQueryString());
         }
+
+        mNameMatcher = new SmartDialNameMatcher("", SmartDialPrefix.getMap());
 
         if (getQueryString() == null) {
             loader.configureQuery("");

--- a/src/com/android/dialer/settings/DisplayOptionsSettingsFragment.java
+++ b/src/com/android/dialer/settings/DisplayOptionsSettingsFragment.java
@@ -16,16 +16,97 @@
 
 package com.android.dialer.settings;
 
+import android.content.Context;
 import android.os.Bundle;
+import android.preference.ListPreference;
+import android.preference.Preference;
 import android.preference.PreferenceFragment;
+import android.text.TextUtils;
 
 import com.android.dialer.R;
 
-public class DisplayOptionsSettingsFragment extends PreferenceFragment {
+import cyanogenmod.providers.CMSettings;
+
+import java.util.Locale;
+
+public class DisplayOptionsSettingsFragment extends PreferenceFragment
+        implements Preference.OnPreferenceChangeListener {
+
+    private static final String BUTTON_T9_SEARCH_INPUT_LOCALE = "button_t9_search_input";
+
+    private ListPreference mT9SearchInputLocale;
+    private Context mContext;
+
+    // t9 search input locales that we have a custom overlay for
+    private static final Locale[] T9_SEARCH_INPUT_LOCALES = new Locale[] {
+            new Locale("ko"), new Locale("el"), new Locale("ru"),
+            new Locale("he"), new Locale("uk")
+    };
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        mContext = getActivity().getApplicationContext();
+
         addPreferencesFromResource(R.xml.display_options_settings);
+
+        mT9SearchInputLocale = (ListPreference) findPreference(BUTTON_T9_SEARCH_INPUT_LOCALE);
+        if (mT9SearchInputLocale != null) {
+            initT9SearchInputPreferenceList();
+            mT9SearchInputLocale.setOnPreferenceChangeListener(this);
+        }
+    }
+
+    /**
+     * Supports onPreferenceChangeListener to look for preference changes.
+     *
+     * @param preference The preference to be changed
+     * @param objValue The value of the selection, NOT its localized display value.
+     */
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object objValue) {
+        if (preference == mT9SearchInputLocale) {
+            saveT9SearchInputLocale(preference, (String) objValue);
+        }
+        return true;
+    }
+
+    private void saveT9SearchInputLocale(Preference preference, String newT9Locale) {
+        String lastT9Locale = CMSettings.System.getString(mContext.getContentResolver(),
+                CMSettings.System.T9_SEARCH_INPUT_LOCALE);
+
+        if (!TextUtils.equals(lastT9Locale, newT9Locale)) {
+            CMSettings.System.putString(mContext.getContentResolver(),
+                    CMSettings.System.T9_SEARCH_INPUT_LOCALE, newT9Locale);
+        }
+    }
+
+    private void initT9SearchInputPreferenceList() {
+        int len = T9_SEARCH_INPUT_LOCALES.length + 1;
+        String[] entries = new String[len];
+        String[] values = new String[len];
+
+        entries[0] = getString(R.string.t9_search_input_locale_default);
+        values[0] = Locale.getDefault().getLanguage();
+
+        // add locales programatically so we can use locale.getDisplayName
+        for (int i = 0; i < T9_SEARCH_INPUT_LOCALES.length; i++) {
+            Locale locale = T9_SEARCH_INPUT_LOCALES[i];
+            entries[i + 1] = locale.getDisplayName();
+            values[i + 1] = locale.toString();
+        }
+
+        // Set current entry from global system setting
+        String settingsT9Locale = CMSettings.System.getString(mContext.getContentResolver(),
+                CMSettings.System.T9_SEARCH_INPUT_LOCALE);
+        if (settingsT9Locale != null) {
+            mT9SearchInputLocale.setValue(settingsT9Locale);
+        }
+
+        mT9SearchInputLocale.setEntries(entries);
+        mT9SearchInputLocale.setEntryValues(values);
+        if (mT9SearchInputLocale.getValue().equals("")) {
+            mT9SearchInputLocale.setValueIndex(0);
+        }
     }
 }

--- a/tests/src/com/android/dialer/dialpad/SmartDialNameMatcherTest.java
+++ b/tests/src/com/android/dialer/dialpad/SmartDialNameMatcherTest.java
@@ -30,8 +30,14 @@ import java.util.ArrayList;
 import junit.framework.TestCase;
 
 @SmallTest
-public class SmartDialNameMatcherTest extends TestCase {
+public class SmartDialNameMatcherTest extends AndroidTestCase {
     private static final String TAG = "SmartDialNameMatcherTest";
+
+    @Override
+    public void setUp() {
+        SmartDialPrefix.setSmartDialMap(new LatinSmartDialMap());
+        SmartDialPrefix.setUserInNanpRegion(true);
+    }
 
     public void testMatches() {
         // Test to ensure that all alphabetic characters are covered
@@ -162,6 +168,30 @@ public class SmartDialNameMatcherTest extends TestCase {
         fail("Cyrillic letters aren't supported yet.");
     }
 
+    public void testMatches_chinese() {
+        SmartDialPrefix.setSmartDialMap(new ChineseSmartDialMap());
+
+        // basic cases
+        checkMatches("红霞李", "46", true, 0, 1);
+        checkMatches("红霞李", "46649", true, 0, 1, 1, 2);
+        checkMatches("红霞李", "5", true, 2, 3);
+        checkMatches("红霞李", "466494254", true, 0, 1, 1, 2, 2, 3);
+
+        // test with spaces
+        checkMatches("红霞 李", "466494254", true, 0, 1, 1, 2, 2, 3);
+        checkMatches(" 红  霞    李", "466494254", true, 0, 1, 1, 2, 2, 3);
+
+        // when character sets are mixed, match english only
+        checkMatches("Hongxia 李", "46", true, 0, 2);
+        checkMatches("Hongxia 李", "5", false);
+
+        // make sure regular english cases still work
+        checkMatches("Meow Face", "63", true, 0, 2);
+        checkMatches("Meow Face", "32", true, 5, 7);
+        checkMatches("Meow Face", "632", true, 0, 1, 5, 7);
+
+        SmartDialPrefix.setSmartDialMap(new LatinSmartDialMap());
+    }
 
     public void testMatches_NumberBasic() {
         // Simple basic examples that start the match from the start of the number
@@ -199,6 +229,7 @@ public class SmartDialNameMatcherTest extends TestCase {
 
     public void testMatches_NumberNANP() {
         SmartDialPrefix.setUserInNanpRegion(true);
+
         // An 11 digit number prefixed with 1 should be matched by the 10 digit number, as well as
         // the 7 digit number (without area code)
         checkMatchesNumber("1-510-333-7596", "5103337596", true, true, 2, 14);
@@ -253,8 +284,8 @@ public class SmartDialNameMatcherTest extends TestCase {
         final SmartDialNameMatcher matcher = new SmartDialNameMatcher(query);
         final ArrayList<SmartDialMatchPosition> matchPositions =
                 new ArrayList<SmartDialMatchPosition>();
-        final boolean matches = matcher.matchesCombination(
-                displayName, query, matchPositions);
+        final boolean matches =
+                SmartDialPrefix.getMap().matchesCombination(matcher, displayName, query, matchPositions);
         Log.d(TAG, "query=" + query + "  text=" + displayName
                 + "  nfd=" + Normalizer.normalize(displayName, Normalizer.Form.NFD)
                 + "  nfc=" + Normalizer.normalize(displayName, Normalizer.Form.NFC)


### PR DESCRIPTION
* Squash of the following:

Revert "dialer: Remove proprietary SmartDial extension"

This reverts commit 31eaffee82c53fb660a6f482afc74902a6c1ddf4.

Change-Id: I893b37b58731f8823ead441d09ec3c45f5b68da6

Russian T9 for Dialer

Change-Id: Ib99ff7b9ef5184db0450fe1bc8a6de79eb7efe24

Dialer: Add Greek T9 support

Change-Id: I006745075cbb83b23a6bda170032d146d9bc5aea

Hebrew T9 for Dialer

Please check it.
The implimentaion is built on the "Russian T9 for dialer".
Also added support for English but in Israel.

Change-Id: I58bfbdf053aff94e446d54f2649070a7cebd488b

Add Korean smart dial map

Change-Id: I93b8efa9093fce4f125e6ebe5b02b5fd581cd01a

Dialer: Refactor SmartDial for additional languages

Adds Chinese support and improved Korean support.

p4: Refactor for transliterating the displayName.

Change-Id: Id3175c6f4eda4962be9d25bd43c24a834c3c5ff1

Read option for t9 search input locale and refresh smart dial db when locale changes

Change-Id: I3cd942741310f16678ed9eb675bbba2cbc72d5e8

Add setting for t9 search input locale

Change-Id: I410b4e20afa85302a9ef3174c2f219e33b1b7987

Return match positions to enable highlighting for CN smart dial

Change-Id: I9255c582708c2fbfe22e7a2bf3ad971da692e2a9

Dialer: Fix T9 for Hebrew

Change-Id: I1c8be92acc1fc29b557eb7cda0d910cf036f3aea

Move smart dialer initialization to onStart().

The SmartDialCursorLoader expects the SmartDialPrefix map to be
initialized when it's created. As
- the loader is initialized in SmartDialSearchFragment's onStart and
- the fragment's onStart is called asynchronously after the activity's
  onStart and
- the map initialization happens in
  SmartDialPrefix.initializeNanpSettings() and
- the above method is currently called in the activity's onResume()

we have a race condition between the activity's onResume() and the
fragment's onStart() (at least when processing a dial intent, which is
what causes the dialpad fragment to be immediately shown).

Fix that race condition by moving the initialization into the activity's
onStart() and running it before calling the super method to ensure it
happens before fragments are started.

JIRA:NIGHTLIES-760
Change-Id: I9767cbba3b177fdd5b1de86914cb1e40d20835ab

Ensure the smart dial name matcher is initialized in onStart().

Otherwise SmartDialPrefix.getMap() might not be initialized yet.

JIRA: NIGHTLIES-1279
Change-Id: If3aca2809faf0c1f379518096a76f17d357fb8e2

Add Ukrainian T9 symbol map

Pretty close to Russian, but with a few differences

Ref CYNGNOS-2188

Change-Id: I29b2cf54fd61ec259e8a01bcedef548ec2fe91cc

Dialer: nuke proprietary smartsearch library references

We really should not use this.

Change-Id: I51395e475a0d9de2b31493d16ac08df72f2d996f

Feijao: empty string is not a valid locale

Empty string is not a valid locale. Setting the default locale
to english (en).

Change-Id: I7bc524dbb4aa65d31f1bb33fa5e8fadf4770fbaf
Issue-Id: FEIJ-306, CD-620

Dialer: use actually supported layouts for SmartDial

Change-Id: I7aafab71c6f8d904292bb82796ab39dc84e88253

Change-Id: I53674f3445ad4a39fdae76cd1afc4d8d27241b36